### PR TITLE
Update Readme to account for EKS 1.28 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the cloned repository:
 
 ```
 packer init .
-packer build -var kubernetes_version=1.27 amazon-ebs.pkr.hcl
+packer build -var kubernetes_version=1.28 amazon-ebs.pkr.hcl
 ```
 
 The source AMI can be overridden by specifying the `source_ami_id` variable,
@@ -34,7 +34,7 @@ e.g.:
 
 ```
 packer build \
-  -var kubernetes_version=1.26 \
+  -var kubernetes_version=1.27 \
   -var source_ami_id=ami-0f114867066b78822
 ```
 
@@ -43,7 +43,7 @@ map of tags as the `tags` variable, e.g.:
 
 ```
 packer build \
-  -var kubernetes_version=1.25 \
+  -var kubernetes_version=1.27 \
   -var 'tags={"mykey": "myvalue", "myotherkey": "myothervalue"}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ e.g.:
 
 ```
 packer build \
-  -var kubernetes_version=1.27 \
+  -var kubernetes_version=1.28 \
   -var source_ami_id=ami-0f114867066b78822
 ```
 
@@ -43,7 +43,7 @@ map of tags as the `tags` variable, e.g.:
 
 ```
 packer build \
-  -var kubernetes_version=1.27 \
+  -var kubernetes_version=1.28 \
   -var 'tags={"mykey": "myvalue", "myotherkey": "myothervalue"}'
 ```
 


### PR DESCRIPTION
Update Readme to account for EKS 1.28 support.

See also https://github.com/ios-xr/xrd-terraform/pull/10.