### PR TITLE
Add a tag for the Amazon Linux version to xrd-packer

### DIFF
--- a/amazon-ebs.pkr.hcl
+++ b/amazon-ebs.pkr.hcl
@@ -26,10 +26,11 @@ variable "tags" {
 
 locals {
   default_tags = {
-    Generated_By       = "xrd-packer"
-    Kubernetes_Version = var.kubernetes_version
-    Base_AMI_ID        = "{{ .SourceAMI }}"
-    Base_AMI_Name      = "{{ .SourceAMIName }}"
+    Generated_By         = "xrd-packer"
+    Kubernetes_Version   = var.kubernetes_version
+    Base_AMI_ID          = "{{ .SourceAMI }}"
+    Base_AMI_Name        = "{{ .SourceAMIName }}"
+    Amazon_Linux_Version = "AL2"
   }
 }
 


### PR DESCRIPTION
Start tagging AL2 images now ready for when we switch to AL2023.