### PR TITLE
Clone dpdk-kmods repo for igb_uio

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ e.g.:
 ```
 packer build \
   -var kubernetes_version=1.32 \
-  -var source_ami_id=ami-0f114867066b78822
+  -var source_ami_id=ami-0f114867066b78822 \
+  amazon-ebs.pkr.hcl
 ```
 
 Arbitrary additional tags can be added to the AMI by specifying a JSON
@@ -44,7 +45,8 @@ map of tags as the `tags` variable, e.g.:
 ```
 packer build \
   -var kubernetes_version=1.32 \
-  -var 'tags={"mykey": "myvalue", "myotherkey": "myothervalue"}'
+  -var 'tags={"mykey": "myvalue", "myotherkey": "myothervalue"}' \
+  amazon-ebs.pkr.hcl
 ```
 
 ## Using AMIs

--- a/install.sh
+++ b/install.sh
@@ -4,7 +4,9 @@
 set -x
 
 # Download and build the igb_uio driver, and load it into the kernel.
-yum install -y "kernel-devel-$(uname -r)"
+yum install -y \
+    "kernel-devel-$(uname -r)" \
+    git
 
 mkdir igb_uio
 curl https://git.dpdk.org/dpdk-kmods/snapshot/dpdk-kmods-e721c733cd24206399bebb8f0751b0387c4c1595.tar.gz | tar -xz -C igb_uio --strip-components 1

--- a/install.sh
+++ b/install.sh
@@ -10,9 +10,9 @@ yum install -y \
 # Download and build the igb_uio driver, and load it into the kernel.
 git clone git://dpdk.org/dpdk-kmods
 cd dpdk-kmods
-git checkout e721c733cd24206399bebb8f0751b0387c4c1595
-make -C dpdk-kmods/linux/igb_uio
-cp dpdk-kmods/linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
+git switch e721c733cd24206399bebb8f0751b0387c4c1595 --detach
+make -C linux/igb_uio
+cp linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
 depmod "$(uname -r)"
 cd ../
 rm -rf dpdk-kmods

--- a/install.sh
+++ b/install.sh
@@ -38,7 +38,9 @@ mkdir tuned
 curl -L https://github.com/redhat-performance/tuned/archive/refs/tags/v2.20.0.tar.gz | tar -xz -C tuned --strip-components 1
 # N.B. The 'desktop-file-install' action is expected to fail. This doesn't
 # affect the installation of the tuned service.
-make -C tuned PYTHON=/usr/bin/python2 install
+if ! make -C tuned PYTHON=/usr/bin/python2 install; then
+    echo "desktop-file-install failure is expected. Continuing with installation..."
+fi
 rm -rf tuned
 
 # Set up the sysctls.

--- a/install.sh
+++ b/install.sh
@@ -1,19 +1,18 @@
 #!/usr/bin/env bash
 # This script must be run as the root user.
 
-set -x
+set -ex
 
 # Download and build the igb_uio driver, and load it into the kernel.
 yum install -y \
     "kernel-devel-$(uname -r)" \
     git
 
-mkdir igb_uio
-curl https://git.dpdk.org/dpdk-kmods/snapshot/dpdk-kmods-e721c733cd24206399bebb8f0751b0387c4c1595.tar.gz | tar -xz -C igb_uio --strip-components 1
-make -C igb_uio/linux/igb_uio
-cp igb_uio/linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
+git clone git://dpdk.org/dpdk-kmods
+make -C dpdk-kmods/linux/igb_uio
+cp dpdk-kmods/linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
 depmod "$(uname -r)"
-rm -rf igb_uio
+rm -rf dpdk-kmods
 
 # Download a much newer version of TuneD that available from the
 # Amazon Linux 2 repositories. This fixes several issues with the old

--- a/install.sh
+++ b/install.sh
@@ -3,15 +3,18 @@
 
 set -ex
 
-# Download and build the igb_uio driver, and load it into the kernel.
 yum install -y \
     "kernel-devel-$(uname -r)" \
     git
 
+# Download and build the igb_uio driver, and load it into the kernel.
 git clone git://dpdk.org/dpdk-kmods
+cd dpdk-kmods
+git checkout e721c733cd24206399bebb8f0751b0387c4c1595
 make -C dpdk-kmods/linux/igb_uio
 cp dpdk-kmods/linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
 depmod "$(uname -r)"
+cd ../
 rm -rf dpdk-kmods
 
 # Download a much newer version of TuneD that available from the


### PR DESCRIPTION
The web address hosting the dpdk-kmods snapshots sometimes goes down. So instead of relying on this pull the dpdk-kmods git repo to get the igb_uio driver.

Also change script to exit on failure.

Tested by running VPET throughput suite on an AMI generated by the updated script.

Tested by:
* Booting XRd on AMI and checking dmesg for write combine
* Running VPET throughput suite on an AMI generated by the updated script