### PR TITLE
Clone dpdk-kmods repo for igb_uio

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ e.g.:
 ```
 packer build \
   -var kubernetes_version=1.32 \
-  -var source_ami_id=ami-0f114867066b78822
+  -var source_ami_id=ami-0f114867066b78822 \
+  amazon-ebs.pkr.hcl
 ```
 
 Arbitrary additional tags can be added to the AMI by specifying a JSON
@@ -44,7 +45,8 @@ map of tags as the `tags` variable, e.g.:
 ```
 packer build \
   -var kubernetes_version=1.32 \
-  -var 'tags={"mykey": "myvalue", "myotherkey": "myothervalue"}'
+  -var 'tags={"mykey": "myvalue", "myotherkey": "myothervalue"}' \
+  amazon-ebs.pkr.hcl
 ```
 
 Note that when building the AMI, the following warnings are expected and can be ignored:

--- a/install.sh
+++ b/install.sh
@@ -11,9 +11,12 @@ dnf install -y \
 # N.B. A warning for 'Skipping BTF generation' is expected. This doesn't affect
 # the performance of the built driver.
 git clone git://dpdk.org/dpdk-kmods
-make -C dpdk-kmods/linux/igb_uio
+cd dpdk-kmods
+git checkout e721c733cd24206399bebb8f0751b0387c4c1595
+make -C linux/igb_uio
 cp dpdk-kmods/linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
 depmod "$(uname -r)"
+cd ../
 rm -rf dpdk-kmods
 
 # TuneD is not available in the Amazon Linux 2023 repository, so download our

--- a/install.sh
+++ b/install.sh
@@ -12,9 +12,9 @@ dnf install -y \
 # the performance of the built driver.
 git clone git://dpdk.org/dpdk-kmods
 cd dpdk-kmods
-git checkout e721c733cd24206399bebb8f0751b0387c4c1595
+git switch e721c733cd24206399bebb8f0751b0387c4c1595 --detach
 make -C linux/igb_uio
-cp dpdk-kmods/linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
+cp linux/igb_uio/igb_uio.ko "/lib/modules/$(uname -r)/kernel/drivers/uio"
 depmod "$(uname -r)"
 cd ../
 rm -rf dpdk-kmods


### PR DESCRIPTION
The web address hosting the dpdk-kmods snapshots sometimes goes down. So instead of relying on this pull the dpdk-kmods git repo to get the igb_uio driver.

Also change script to exit on failure.

Tested by:
* Booting XRd on AMI and checking dmesg for write combine
* Running VPET throughput suite on an AMI generated by the updated script