### PR TITLE
Fix for Kubernetes 1.33 kernel-devel package rename

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -4,9 +4,10 @@
 set -ex
 
 # Use the dnf repoquery whatprovides command to obtain the name of the relevant
-# kernel-devel package. This is usually of the form "kernel-devel-$(uname -r)"
-# (Kubernetes version <=1.32), but has been known to change to
-# "kernel<truncated uname>-devel-$(uname -r)" (Kubernetes version = 1.33).
+# kernel-devel package (which always provides the tag 'kernel-devel-uname-r').
+# This is usually of the form "kernel-devel-$(uname -r)" (Kubernetes version
+# <=1.32), but has been known to change to "kernel<truncated
+# uname>-devel-$(uname -r)" (Kubernetes version = 1.33).
 devel_pkg=$(dnf repoquery --whatprovides "kernel-devel-uname-r = $(uname -r)")
 
 dnf install -y \

--- a/install.sh
+++ b/install.sh
@@ -3,8 +3,14 @@
 
 set -ex
 
+# Use the dnf repoquery whatprovides command to obtain the name of the relevant
+# kernel-devel package. This is usually of the form "kernel-devel-$(uname -r)"
+# (Kubernetes version <=1.32), but has been known to change to
+# "kernel<truncated uname>-devel-$(uname -r)" (Kubernetes version = 1.33).
+devel_pkg=$(dnf repoquery --whatprovides "kernel-devel-uname-r = $(uname -r)")
+
 dnf install -y \
-    "kernel-devel-$(uname -r)" \
+    "$devel_pkg" \
     git
 
 # Download and build the igb_uio driver, and load it into the kernel.


### PR DESCRIPTION
## Bug Description 
The naming convention of the kernel-devel packages for earlier Kubernetes versions (<= 1.32) all follow `kernel-devel-uname`, but from version 1.33 and potentially onwards, the package naming convention seems to be `kernel<truncated-uname>-devel-uname`.

## Fix Explanation
Instead of hardcoding the format of the package name, replace this with a dnf repoquery whatprovides call to return the true kernel-devel package name for any version. This will increase the time taken for the command on the order of 10-30 seconds, but future-proofs the kernel-devel package acquisition.

This works because packages have certain tags that can be queried by dnf. It seems like the `kernel-devel-uname-r` tag is one present on `kernel-devel` packages whose value can be matched to `uname -r`. Any of these tags are searchable using the `dnf repoquery --whatprovides` command, therefore the correct `kernel-devel` package can be obtained.

## Testing
- Ran packer build on version 1.33 and 1.32 √
- Ran EKS sanity on version 1.33 √